### PR TITLE
Configure drizzle-kit for db migrations

### DIFF
--- a/apps/api/src/routes/tasks/url-metadata.ts
+++ b/apps/api/src/routes/tasks/url-metadata.ts
@@ -6,7 +6,7 @@ import {
 	queues,
 } from "@playfulprogramming/common";
 import { db } from "@playfulprogramming/db";
-import { Type } from "@sinclair/typebox";
+import { Type, type Static } from "@sinclair/typebox";
 
 const UrlMetadataResponseSchema = Type.Object({
 	title: Type.Optional(Type.String()),
@@ -14,13 +14,16 @@ const UrlMetadataResponseSchema = Type.Object({
 	banner: Type.Optional(Type.String()),
 });
 
-function getPublicUrl(key: string): URL {
+function getPublicUrl(key: string): string {
 	const s3PublicUrl = `${process.env.S3_PUBLIC_URL}/${process.env.S3_BUCKET}/`;
-	return new URL(key, s3PublicUrl);
+	return new URL(key, s3PublicUrl).toString();
 }
 
 const urlMetadataRoutes: FastifyPluginAsync = async (fastify) => {
-	fastify.post<{ Body: UrlMetadataInput }>(
+	fastify.post<{
+		Body: UrlMetadataInput;
+		Reply: Static<typeof UrlMetadataResponseSchema>;
+	}>(
 		"/tasks/url-metadata",
 		{
 			schema: {
@@ -55,7 +58,7 @@ const urlMetadataRoutes: FastifyPluginAsync = async (fastify) => {
 			if (existingMetadata) {
 				reply.code(200);
 				reply.send({
-					title: existingMetadata.title,
+					title: existingMetadata.title || undefined,
 					icon: existingMetadata.icon
 						? getPublicUrl(existingMetadata.icon)
 						: undefined,

--- a/apps/api/src/routes/tasks/url-metadata.ts
+++ b/apps/api/src/routes/tasks/url-metadata.ts
@@ -1,5 +1,4 @@
 import type { FastifyPluginAsync } from "fastify";
-import { createHash } from "crypto";
 import { eq } from "drizzle-orm";
 import {
 	type UrlMetadataInput,
@@ -14,6 +13,11 @@ const UrlMetadataResponseSchema = Type.Object({
 	icon: Type.Optional(Type.String()),
 	banner: Type.Optional(Type.String()),
 });
+
+function getPublicUrl(key: string): URL {
+	const s3PublicUrl = `${process.env.S3_PUBLIC_URL}/${process.env.S3_BUCKET}/`;
+	return new URL(key, s3PublicUrl);
+}
 
 const urlMetadataRoutes: FastifyPluginAsync = async (fastify) => {
 	fastify.post<{ Body: UrlMetadataInput }>(
@@ -44,22 +48,36 @@ const urlMetadataRoutes: FastifyPluginAsync = async (fastify) => {
 				inputUrl.origin.toLowerCase(),
 			).toString();
 
-			const urlHash = createHash("md5").update(normalizedUrl).digest("hex");
-
 			const existingMetadata = await db.query.urlMetadata.findFirst({
-				where: (metadata) => eq(metadata.id, urlHash),
+				where: (metadata) => eq(metadata.url, normalizedUrl),
 			});
 
 			if (existingMetadata) {
 				reply.code(200);
-				reply.send(existingMetadata);
+				reply.send({
+					title: existingMetadata.title,
+					icon: existingMetadata.icon
+						? getPublicUrl(existingMetadata.icon)
+						: undefined,
+					banner: existingMetadata.banner
+						? getPublicUrl(existingMetadata.banner)
+						: undefined,
+				});
 				return;
 			}
 
-			await queues["url-metadata"].add(urlHash, {
-				...request.body,
-				url: normalizedUrl,
-			});
+			await queues["url-metadata"].add(
+				normalizedUrl,
+				{
+					...request.body,
+					url: normalizedUrl,
+				},
+				{
+					deduplication: {
+						id: normalizedUrl,
+					},
+				},
+			);
 
 			reply.code(202);
 		},

--- a/apps/worker/src/createWorker.ts
+++ b/apps/worker/src/createWorker.ts
@@ -10,5 +10,13 @@ export function createWorker<T extends TasksValues>(
 	task: T,
 	callback: (job: Job<TaskInputs[T]>) => Promise<void>,
 ): Worker {
-	return new Worker(task, callback, { connection: redis });
+	return new Worker(
+		task,
+		async (job) => {
+			const result = await callback(job);
+			console.log(`Completed job ${job.id}:`, result);
+			return result;
+		},
+		{ connection: redis },
+	);
 }

--- a/apps/worker/src/tasks/url-metadata/utils/fetchPageHtml.ts
+++ b/apps/worker/src/tasks/url-metadata/utils/fetchPageHtml.ts
@@ -6,6 +6,7 @@ export const isElement = (e: Root | Element | Node | undefined): e is Element =>
 	e?.type == "element";
 
 export async function fetchAsBrowser(input: URL, init?: RequestInit) {
+	console.log(`Fetching URL: ${input}`);
 	const response = await fetch(input, {
 		...init,
 		headers: {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"build": "nx affected --target=build",
 		"build:all": "nx run-many --target=build",
 		"dev:libs": "nx watch --all -- nx run-many --targets=build --exclude=api,worker",
-		"dev": "pnpm run build:all && nx run-many --targets=dev,dev:libs",
+		"dev": "pnpm run build:all && nx run-many --targets=drizzle:push,dev,dev:libs",
 		"prettier": "prettier . --check --ignore-unknown",
 		"prettier:write": "prettier . --write --ignore-unknown"
 	},

--- a/packages/common/src/s3/client.ts
+++ b/packages/common/src/s3/client.ts
@@ -76,12 +76,11 @@ export async function exists(bucket: string, key: string) {
 export async function upload(
 	bucket: string,
 	key: string,
-	tags: Record<string, string>,
+	tag: string | undefined,
 	file: stream.Readable,
 	contentType: string,
 ) {
 	console.log(`Uploading ${bucket}/${key}`);
-	const searchParams = new URLSearchParams(tags);
 
 	const upload = new Upload({
 		params: {
@@ -89,7 +88,7 @@ export async function upload(
 			Key: key,
 			Body: file,
 			ContentType: contentType,
-			Tagging: searchParams.toString(),
+			Tagging: tag,
 		},
 		client,
 	});

--- a/packages/db/drizzle.config.ts
+++ b/packages/db/drizzle.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "drizzle-kit";
+import { config } from "dotenv";
+
+config({ path: "../../.env" });
+
+console.log(process.env.POSTGRES_URL);
+
+export default defineConfig({
+	out: "./drizzle",
+	schema: "./src/schema",
+	dialect: "postgresql",
+	dbCredentials: {
+		url: process.env.POSTGRES_URL!,
+	},
+});

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -7,6 +7,7 @@
 	"scripts": {
 		"test:eslint": "eslint ./src",
 		"test:build": "publint --strict",
+		"drizzle:push": "drizzle-kit push",
 		"build": "tsc --noEmit"
 	},
 	"dependencies": {
@@ -14,6 +15,8 @@
 		"pg": "^8.15.6"
 	},
 	"devDependencies": {
-		"@types/pg": "^8.11.11"
+		"@types/pg": "^8.11.11",
+		"dotenv": "^16.5.0",
+		"drizzle-kit": "^0.31.0"
 	}
 }

--- a/packages/db/src/schema/url-metadata.ts
+++ b/packages/db/src/schema/url-metadata.ts
@@ -1,11 +1,7 @@
 import { pgTable, varchar } from "drizzle-orm/pg-core";
-import { sql } from "drizzle-orm";
 
 export const urlMetadata = pgTable("url_metadata", {
-	id: varchar("id", { length: 32 })
-		.primaryKey()
-		.$defaultFn(() => sql`md5(url)`),
-	url: varchar("url", { length: 2048 }).notNull(),
+	url: varchar("url", { length: 2048 }).primaryKey(),
 	title: varchar("title", { length: 2048 }),
 	icon: varchar("icon", { length: 2048 }),
 	banner: varchar("banner", { length: 2048 }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,6 +161,12 @@ importers:
       '@types/pg':
         specifier: ^8.11.11
         version: 8.11.11
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.5.0
+      drizzle-kit:
+        specifier: ^0.31.0
+        version: 0.31.0
 
 packages:
 
@@ -1784,6 +1790,10 @@ packages:
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dotenv@16.5.0:
+    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
 
   drizzle-kit@0.31.0:
@@ -5231,6 +5241,8 @@ snapshots:
       dotenv: 16.4.7
 
   dotenv@16.4.7: {}
+
+  dotenv@16.5.0: {}
 
   drizzle-kit@0.31.0:
     dependencies:


### PR DESCRIPTION
Sets up drizzle-kit tasks and fixes the `/tasks/url-metadata` endpoint